### PR TITLE
feat: initial setup for MyLibrary page with book modal, notes handlin…

### DIFF
--- a/backend/src/controllers/books.controller.js
+++ b/backend/src/controllers/books.controller.js
@@ -3,6 +3,8 @@ import { sendSuccess, sendError } from "../utils/sendResponse.js";
 import openAI from "openai";
 import dotenv from "dotenv";
 import User from "../models/user.models.js";
+import { update } from "three/examples/jsm/libs/tween.module.js";
+import { equal } from "three/tsl";
 dotenv.config();
 
 //Home page route
@@ -84,7 +86,7 @@ export const ourStory = (req, res) => {
 
 export const addBookToLibrary = async (req, res) => {
   const { title, author, summary } = req.body;
-  
+
   try {
     const userId = req.user._id;
     const coverResponse = await axios.get(
@@ -113,18 +115,110 @@ export const addBookToLibrary = async (req, res) => {
   }
 };
 
-export const getLibrary = async (req, res) =>{
+export const deleteBookFromLibrary = async (req, res) => {
   try {
-    const user = await User.findById(req.user.id)
-    if(!user){
-      return sendError(res, "User not found", 404)
+    const userId = req.user.id;
+    const bookId = req.params.bookId;
+
+    const user = await User.findById(userId);
+    if (!user) return sendError(res, "User not found", 404);
+
+    const initialLength = user.library.length;
+
+    user.library = user.library.filter((b) => b._id.toString() !== bookId);
+
+    if (user.library.length === initialLength) {
+      return sendError(res, "Book not found in user's library", 404);
     }
-    sendSuccess(res, user.library, 200)
+
+    await user.save();
+
+    return res.status(200).json({
+      success: true,
+      message: "Book successfully removed from library",
+    });
+  } catch (error) {
+    console.error("Error deleting book from library:", error);
+    return sendError(res, "Server error", 500);
+  }
+};
+
+export const getLibrary = async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id);
+    if (!user) {
+      return sendError(res, "User not found", 404);
+    }
+    sendSuccess(res, user.library, 200);
   } catch (error) {
     console.log("Error in fetching library:", error.message);
-    sendError(res)
+    sendError(res);
   }
-}
+};
+
+export const getNote = async (req, res) => {
+  try {
+    console.log("User id:", req.user._id);
+    console.log("Book id:", req.params.bookId);
+    const user = await User.findById(req.user._id);
+    const book = user.library.id(req.params.bookId);
+    if (!book) return sendError(res, "Book not found", 404);
+    sendSuccess(res, book.notes || "", 200);
+  } catch (error) {
+    console.log("Error in getNotes controller", error.message);
+    sendError(res);
+  }
+};
+
+export const createNote = async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id);
+    const book = user.library.id(req.params.bookId);
+
+    if (!book) return sendError(res, "Book not found", 404);
+
+    if (book.notes && book.notes.trim() !== "") {
+      return sendError(res, "Book already exists", 409);
+    }
+
+    book.notes = req.body.note || "";
+    await user.save();
+    sendSuccess(res, { note: book.notes }, "Note Created", 201);
+  } catch (error) {
+    console.log("Error in createNote controller", error.message);
+    sendError(res);
+  }
+};
+
+export const updateNote = async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id);
+    const book = user.library.id(req.params.bookId);
+
+    if (!book) return sendError(res, "Book not found", 404);
+    if (!book.notes) return sendError(res, "No book notes to update", 404);
+    book.notes = req.body.note || "";
+    await user.save();
+    sendSuccess(res, "Notes Updated", 200);
+  } catch (error) {
+    console.log("Error in updateNotes controller", error.message);
+    sendError(res);
+  }
+};
+
+export const deleteNote = async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id);
+    const book = user.library.id(req.params.bookId);
+    if (!book) return sendError(res, "Book not found", 404);
+    book.notes = "";
+    await user.save();
+    sendSuccess(res, "Notes deleted", 200);
+  } catch (error) {
+    console.log("Error in delete note controller: ", error.message);
+    sendError(res);
+  }
+};
 
 export default {
   homePage,
@@ -133,5 +227,8 @@ export default {
   searchPage,
   ourStory,
   addBookToLibrary,
-  getLibrary
+  getLibrary,
+  getNote,
+  updateNote,
+  deleteNote,
 };

--- a/backend/src/routes/books.route.js
+++ b/backend/src/routes/books.route.js
@@ -7,6 +7,11 @@ import {
   ourStory,
   addBookToLibrary,
   getLibrary,
+  getNote,
+  updateNote,
+  createNote,
+  deleteNote,
+  deleteBookFromLibrary,
 } from "../controllers/books.controller.js";
 import { protectRoute } from "../middleware/auth.middleware.js";
 
@@ -15,8 +20,18 @@ const router = express.Router();
 router.get("/", homePage);
 router.get("/searchPage", searchPage);
 router.get("/ourStory", ourStory);
-router.post("/mylibrary", protectRoute, addBookToLibrary )
-router.get("/mylibrary",protectRoute, getLibrary)
+
+router.get("/mylibrary", protectRoute, getLibrary);
+router.post("/mylibrary", protectRoute, addBookToLibrary);
+router.delete("/mylibrary/:bookId", protectRoute, deleteBookFromLibrary);
+
+
+
+router.get("/mylibrary/:bookId/notes", protectRoute, getNote);
+router.post("/mylibrary/:bookId/notes", protectRoute, createNote);
+router.patch("/mylibrary/:bookId/notes", protectRoute, updateNote);
+router.delete("/mylibrary/:bookId/notes", protectRoute, deleteNote);
+
 router.post("/openai-summary", searchOpenAi);
 router.post("/youtube-recaps", searchBookYT);
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.2",
+        "tailwind-scrollbar": "^4.0.2",
         "tailwindcss": "^4.1.10",
         "zustand": "^5.0.6"
       },
@@ -1888,6 +1889,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -2111,6 +2118,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -3497,6 +3513,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prism-react-renderer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
+      "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3737,6 +3766,21 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-scrollbar": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-4.0.2.tgz",
+      "integrity": "sha512-wAQiIxAPqk0MNTPptVe/xoyWi27y+NRGnTwvn4PQnbvB9kp8QUBiGl/wsfoVBHnQxTmhXJSNt9NHTmcz9EivFA==",
+      "license": "MIT",
+      "dependencies": {
+        "prism-react-renderer": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "4.x"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2",
+    "tailwind-scrollbar": "^4.0.2",
     "tailwindcss": "^4.1.10",
     "zustand": "^5.0.6"
   },

--- a/frontend/src/components/BookDetailModal.jsx
+++ b/frontend/src/components/BookDetailModal.jsx
@@ -1,0 +1,202 @@
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+const BookDetailModal = ({ book, isOpen, onClose, onUpdateLibrary }) => {
+  const [note, setNote] = useState("");
+  const [originalNote, setOriginalNote] = useState("");
+  const [editing, setEditing] = useState(false);
+
+  function toPascalCase(str) {
+    return str
+      .split(/[\s_-]+/)
+      .map((word) => {
+        if (word.length === 0) return "";
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+      })
+      .join(" ");
+  }
+
+  useEffect(() => {
+    if (!book) return;
+
+    const fetchNote = async () => {
+      try {
+        const res = await axios.get(
+          `http://localhost:3000/api/books/mylibrary/${book._id}/notes`,
+          { withCredentials: true }
+        );
+        const fetchedNote = res.data.data || "";
+        setNote(fetchedNote);
+        setOriginalNote(fetchedNote);
+        setEditing(false);
+      } catch (error) {
+        console.error("Error fetching book note:", error.message);
+      }
+    };
+
+    fetchNote();
+  }, [book]);
+
+  const saveNote = async () => {
+    try {
+      const method = originalNote.trim() ? "patch" : "post";
+      await axios[method](
+        `http://localhost:3000/api/books/mylibrary/${book._id}/notes`,
+        { note },
+        { withCredentials: true }
+      );
+      alert("Note saved");
+      setOriginalNote(note);
+      setEditing(false);
+    } catch (error) {
+      console.error("Error saving note:", error.message);
+      alert("Failed to save note");
+    }
+  };
+
+  const deleteNote = async () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to delete this note?"
+    );
+    if (!confirmed) return;
+
+    try {
+      await axios.delete(
+        `http://localhost:3000/api/books/mylibrary/${book._id}/notes`,
+        { withCredentials: true }
+      );
+      setNote("");
+      setOriginalNote("");
+      setEditing(false);
+      alert("Note deleted");
+    } catch (error) {
+      console.error("Error deleting note:", error.message);
+      alert("Failed to delete note");
+    }
+  };
+
+  const deleteBook = async () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to delete this book?"
+    );
+    if (!confirmed) return;
+
+    try {
+      await axios.delete(
+        `http://localhost:3000/api/books/mylibrary/${book._id}`,
+        { withCredentials: true }
+      );
+
+      alert("Book deleted from library");
+      onUpdateLibrary();
+      onClose();
+    } catch (error) {
+      console.error("Error deleting book:", error.message);
+      alert("Failed to delete book");
+    }
+  };
+
+  if (!isOpen || !book) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black/70 z-50 flex justify-center items-center ${
+        isOpen ? "hover:cursor-pointer" : "hover:cursor-alias"
+      }`}
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl w-full max-w-2xl h-[90vh] overflow-hidden relative flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div id="custom-scroll" className="p-6 overflow-y-auto">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 text-xl font-bold text-gray-600 hover:text-black cursor-pointer"
+          >
+            &times;
+          </button>
+
+          {/* Book Details */}
+          <div className="text-center flex flex-col justify-center items-center hover:cursor-default">
+            <h2 className="text-2xl font-bold">{toPascalCase(book.title)}</h2>
+            <p className="text-sm text-gray-600 mb-2">by {book.author}</p>
+            <img
+              src={book.coverUrl}
+              alt={book.title}
+              className="w-40 my-4 rounded"
+            />
+            <p className="mt-4 text-gray-800">{book.summary}</p>
+          </div>
+
+          {/* Notes Section */}
+          <div className="mt-6">
+            <h3 className="text-lg font-semibold mb-2">
+              {note?.trim() ? "Your Notes" : "Add notes for this book?"}
+            </h3>
+
+            {!editing ? (
+              <div
+                className={`text-gray-800 whitespace-pre-wrap p-3 rounded relative text-center ${
+                  note?.trim() ? "bg-gray-100" : "bg-transparent"
+                }`}
+              >
+                {note?.trim() ? note : ""}
+                <div className="mt-2">
+                  <button
+                    onClick={() => setEditing(true)}
+                    className="cursor-pointer hover:scale-104 active:scale-97"
+                  >
+                    {note?.trim() ? "✍️" : "➕"}
+                  </button>
+                </div>
+                <button
+                  onClick={deleteBook}
+                  className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+                >
+                  Remove Book from Library
+                </button>
+              </div>
+            ) : (
+              <>
+                <textarea
+                  className="w-full p-2 border rounded"
+                  rows={5}
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                />
+                <div className="flex gap-2 mt-2">
+                  <button
+                    onClick={saveNote}
+                    className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer"
+                  >
+                    Save Note
+                  </button>
+                  <button
+                    onClick={() => {
+                      setNote(originalNote);
+                      setEditing(false);
+                    }}
+                    className="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400 cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                  {originalNote && (
+                    <button
+                      onClick={deleteNote}
+                      className="ml-auto px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+                    >
+                      Delete Note
+                    </button>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BookDetailModal;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,3 +10,17 @@ body {
 #brand-header {
   font-family: "Anek Devanagari", sans-serif;
 }
+
+#custom-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+#custom-scroll::-webkit-scrollbar-track {
+  background: transparent;
+  border: none;
+}
+
+#custom-scroll::-webkit-scrollbar-thumb {
+  background-color: rgba(100, 100, 100, 0.5);
+  border-radius: 8px;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,14 +3,11 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
 import { BrowserRouter } from "react-router-dom";
-import {SummaryProvider} from "./context/SummaryCotext.jsx"
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-      <SummaryProvider>
-        <App />
-      </SummaryProvider>
+      <App />
     </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/pages/MyLibraryPage.jsx
+++ b/frontend/src/pages/MyLibraryPage.jsx
@@ -1,25 +1,29 @@
 import MyLibraryHero from "../components/MyLibraryHero";
+import BookDetailModal from "../components/BookDetailModal";
 import { useState, useEffect } from "react";
 import axios from "axios";
+import { Link } from "react-router-dom";
 
 const MyLibraryPage = () => {
   const [library, setLibrary] = useState([]);
+  const [selectedBook, setSelectedBook] = useState(null);
+
+  const fetchLibrary = async () => {
+    try {
+      const response = await axios.get(
+        "http://localhost:3000/api/books/mylibrary",
+        {
+          withCredentials: true,
+        }
+      );
+      setLibrary(response.data.data);
+      console.log("Library Response", response.data);
+    } catch (error) {
+      console.error("Error fetching library:", error);
+    }
+  };
 
   useEffect(() => {
-    const fetchLibrary = async () => {
-      try {
-        const response = await axios.get(
-          "http://localhost:3000/api/books/mylibrary",
-          {
-            withCredentials: true,
-          }
-        );
-        setLibrary(response.data.data);
-        console.log("Library Response", response.data);
-      } catch (error) {
-        console.error("Error fetching library:", error);
-      }
-    };
     fetchLibrary();
   }, []);
 
@@ -31,20 +35,34 @@ const MyLibraryPage = () => {
 
       <div className="relative z-10 px-4 py-10 mt-10">
         <div className="flex justify-center">
-          <div className="w-full max-w-6xl bg-black/30 rounded-3xl p-8 backdrop-blur-sm">
-            <div className="w-full flex p-2 gap-x-15 justify-between">
+          <div className="w-auto max-w-6xl bg-black/30 rounded-3xl p-8 backdrop-blur-sm">
+            <div className="w-full flex p-2 gap-x-15 ">
               {library.map((book) => (
                 <img
                   key={book._id}
                   src={book.coverUrl}
                   alt={`${book.title} cover`}
-                  className="h-35 w-28 rounded-sm"
+                  className="h-35 w-28 rounded-sm cursor-pointer hover:scale-103 active:scale-97"
+                  onClick={() => setSelectedBook(book)}
                 />
               ))}
+            </div>
+            <div className="flex justify-center mt-4 font-semibold text-white hover:underline">
+              <Link to={"/"}>Recap another book?</Link>
             </div>
           </div>
         </div>
       </div>
+
+      {/* {Modal Section} */}
+      {selectedBook && (
+        <BookDetailModal
+          book={selectedBook}
+          isOpen={true}
+          onClose={() => setSelectedBook(null)}
+          onUpdateLibrary={fetchLibrary}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Initial MyLibrary Page + Modal Functionality

## Summary

This PR sets up the foundational structure for the **MyLibrary** feature, where users can:

- View saved books from their personal library
- Open a book in a modal to view details
- Add, edit, and delete personal notes per book
- Remove a book entirely from their library
- Automatically refresh the library UI after deletion

---

## What’s Included

### MyLibrary Page
- Grid layout for rendering saved books
- Clickable covers open a modal with detailed view
- Fetches user’s saved library from backend on mount
- Reactively updates UI after a book is deleted

### BookDetailModal Component
- Displays title, author, cover, and summary
- Converts book title to Pascal Case for display
- Integrates personal note functionality:
  - Add new notes
  - Edit existing notes
  - Delete notes (with confirmation)
- Delete book from library with confirmation prompt
- Triggers `onUpdateLibrary()` prop to refresh main library view after a deletion

---

## Backend Integration
- `GET /api/books/mylibrary` – fetch saved books
- `GET/POST/PATCH/DELETE /api/books/mylibrary/:bookId/notes` – manage notes
- `DELETE /api/books/mylibrary/:bookId` – remove book from library

---

##  Next Steps

- Add styling enhancements for better UX (e.g., transitions, icons, layout tweaks)
- Handle duplicate entries
- Create logout route
- Edit navbar
- Validation handling in original search form

---

## Notes

- Minimal styling for now — focusing on functionality first
- All core state updates and API interactions are in place
