### PR TITLE
Add route guards for /search and /mylibrary pages with fallback

### DIFF
--- a/frontend/src/pages/MyLibraryPage.jsx
+++ b/frontend/src/pages/MyLibraryPage.jsx
@@ -1,12 +1,16 @@
 import MyLibraryHero from "../components/MyLibraryHero";
 import BookDetailModal from "../components/BookDetailModal";
 import { useState, useEffect } from "react";
+import castleHome from "../assets/castle-home.svg";
 import axios from "axios";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import useAuthStore from "../store/useAuthStore";
 
 const MyLibraryPage = () => {
   const [library, setLibrary] = useState([]);
   const [selectedBook, setSelectedBook] = useState(null);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const navigate = useNavigate();
 
   const fetchLibrary = async () => {
     try {
@@ -24,8 +28,10 @@ const MyLibraryPage = () => {
   };
 
   useEffect(() => {
-    fetchLibrary();
-  }, []);
+    if (isAuthenticated) {
+      fetchLibrary();
+    }
+  }, [isAuthenticated]);
 
   return (
     <div className="relative min-h-screen">
@@ -36,20 +42,55 @@ const MyLibraryPage = () => {
       <div className="relative z-10 px-4 py-10 mt-10">
         <div className="flex justify-center">
           <div className="w-auto max-w-6xl bg-black/30 rounded-3xl p-8 backdrop-blur-sm">
-            <div className="w-full flex p-2 gap-x-15 ">
-              {library.map((book) => (
-                <img
-                  key={book._id}
-                  src={book.coverUrl}
-                  alt={`${book.title} cover`}
-                  className="h-35 w-28 rounded-sm cursor-pointer hover:scale-103 active:scale-97"
-                  onClick={() => setSelectedBook(book)}
-                />
-              ))}
-            </div>
-            <div className="flex justify-center mt-4 font-semibold text-white hover:underline">
-              <Link to={"/"}>Recap another book?</Link>
-            </div>
+            {!isAuthenticated ? (
+              <div className="text-center text-white space-y-4">
+                <p className="text-xl font-medium">
+                  Create an account or login to save books to your library.
+                </p>
+                <div className="mt-6 p-6 flex justify-center gap-4">
+                  <button
+                    className="px-4 bg-[#46281E]/80 text-white rounded-full hover:bg-[#BC7647]/80 hover:scale-102 active:scale-97 transition cursor-pointer"
+                    onClick={() => navigate("/login")}
+                  >
+                    Login
+                  </button>
+                  <button
+                    className="px-4 py-2 bg-[#46281E]/80 text-white rounded-full hover:bg-[#BC7647]/80 hover:scale-102 active:scale-97 transition cursor-pointer"
+                    onClick={() => navigate("/signup")}
+                  >
+                    Sign Up
+                  </button>
+                </div>
+                <div>
+                  <Link to={"/"}>
+                    <span className="text-xs font-extralight">HOME</span>
+                    <img
+                      src={castleHome}
+                      alt="Home button"
+                      title="Homepage"
+                      className="w-10 h-10 mx-auto opacity-80 hover:opacity-70 hover:scale-103 active:scale-97 transition  cursor-pointer  "
+                    />
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="w-full flex p-2 gap-x-15 ">
+                  {library.map((book) => (
+                    <img
+                      key={book._id}
+                      src={book.coverUrl}
+                      alt={`${book.title} cover`}
+                      className="h-35 w-28 rounded-sm cursor-pointer hover:scale-103 active:scale-97"
+                      onClick={() => setSelectedBook(book)}
+                    />
+                  ))}
+                </div>
+                <div className="flex justify-center mt-4 font-semibold text-white hover:underline">
+                  <Link to={"/"}>Recap another book?</Link>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/OurStoryPage.jsx
+++ b/frontend/src/pages/OurStoryPage.jsx
@@ -1,4 +1,4 @@
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import OurStoryHero from "../components/OurStoryHero";
 import castleHome from "../assets/castle-home.svg";
 import { motion } from "framer-motion";
@@ -35,35 +35,39 @@ const OurStoryPage = () => {
           className="w-full max-w-3xl bg-[#DECDAE]/40 rounded-3xl p-8 backdrop-blur-sm"
         >
           <div className="max-w-2xl  mx-auto text-center space-y-6 text-shadow-gray-500  md:text-base leading-relaxed">
-            <h3 id="brand-header" className="text-2xl font-semibold">Our Story</h3>
+            <h3 id="brand-header" className="text-2xl font-semibold">
+              Our Story
+            </h3>
             <div className="text-lg">
               <p className="mt-6">
-              <span className=" font-medium text-lg">ChapterRewind</span> was born from
-              a reader’s dilemma: you pick up an epic book series, fall in love
-              with its world & characters, but life or the publishing cycle (or
-              just a really long reading break...) gets in the way. Months or
-              even years pass, and when the next book finally arrives, that
-              once-vivid world feels distant and unfamiliar.
-            </p>
-            <br />
-            <p>
-              When you finally return, you're lost. Names, plots, politics,
-              magic systems are all a blur.
-            </p>
-            <br />
-            <p>
-              This space was built for readers like us. A place to{" "}
-              <span className="italic">refresh your memory</span>,{" "}
-              <span className="italic">reconnect with characters</span>, and{" "}
-              <span className="italic">rewind the story</span> before diving
-              back in. Whether it's a quick recap or a deep re-immersion,{" "}
-              <span className="font-medium">ChapterRewind</span> helps you pick
-              up right where you left off—without starting from page one again.
-            </p>
+                <span className=" font-medium text-lg">ChapterRewind</span> was
+                born from a reader’s dilemma: you pick up an epic book series,
+                fall in love with its world & characters, but life or the
+                publishing cycle (or just a really long reading break...) gets
+                in the way. Months or even years pass, and when the next book
+                finally arrives, that once-vivid world feels distant and
+                unfamiliar.
+              </p>
+              <br />
+              <p>
+                When you finally return, you're lost. Names, plots, politics,
+                magic systems are all a blur.
+              </p>
+              <br />
+              <p>
+                This space was built for readers like us. A place to{" "}
+                <span className="italic">refresh your memory</span>,{" "}
+                <span className="italic">reconnect with characters</span>, and{" "}
+                <span className="italic">rewind the story</span> before diving
+                back in. Whether it's a quick recap or a deep re-immersion,{" "}
+                <span className="font-medium">ChapterRewind</span> helps you
+                pick up right where you left off—without starting from page one
+                again.
+              </p>
             </div>
-            
 
             <button onClick={handleHomeClick} className="mt-6 p-4  ">
+              <span className="text-xs font-extralight">HOME</span>
               <img
                 src={castleHome}
                 alt="Home button"

--- a/frontend/src/pages/SearchPage.jsx
+++ b/frontend/src/pages/SearchPage.jsx
@@ -12,6 +12,9 @@ const SearchPage = ({ setFadeNavItems }) => {
   const { summary, setSummary, videos, setVideos, formData, setFormData } =
     useSummaryStore();
 
+  const noSearchData =
+    (!summary || summary.length == 0) && (!videos || videos.length == 0);
+
   function toPascalCase(str) {
     return str
       .split(/[\s_-]+/)
@@ -74,9 +77,33 @@ const SearchPage = ({ setFadeNavItems }) => {
 
       <div className="relative z-10 px-4 py-10 mt-10">
         <div className="flex justify-center">
-          <div className="w-full max-w-6xl bg-black/30 rounded-3xl p-8 backdrop-blur-sm">
+          <div className="w-auto max-w-6xl bg-black/30 rounded-3xl p-8 backdrop-blur-sm">
             <div className="p-8">
-              {(summary || videos.length > 0) && (
+              {noSearchData ? (
+                <div className="text-white text-center">
+                  <p className="text-4xl mb-6">Nothing to recap just yet.</p>
+                  <p className="text-xs text-gray-400">
+                    Go back to home page to search for a book.
+                  </p>
+                  <div className="flex justify-center">
+                    <div
+                      id="return"
+                      className="flex flex-col  items-center mt-20"
+                    >
+                      <span className="text-xs font-extralight">HOME</span>
+
+                      <Link
+                        to="/"
+                        title="Homepage"
+                        onClick={handleHomeClick}
+                        className=" w-[70px] h-[70px] cursor-pointer flex flex-row justify-center bg-[#F3E9D2]  rounded-full  hover:shadow-md transition mt-1"
+                      >
+                        <BowAnimation />
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+              ) : (
                 <div className="flex flex-col gap-8 mt-10 w-full max-w-6xl">
                   {summary && (
                     <div className="text-white">


### PR DESCRIPTION
## What's New

This PR introduces guard logic for key pages to improve user experience and handle direct URL access.

### Protected Routes

- **`/search`** now shows a message and a link to return home if a user navigates directly to the page without first performing a book search.
- **`/mylibrary`** conditionally renders content based on login status:
  - Logged-out users are shown a prompt to log in or sign up.
  - Logged-in users will see their saved books as expected.

### Improvements
- Prevents confusion when landing on `/search` without any prior input.
- Encourages account creation or login when trying to access saved content.
- Ensures that background visuals and return navigation remain consistent in both fallback and authenticated views.
