### PR TITLE
Unit test for book page related components

### DIFF
--- a/frontend/src/components/Book/BookDetailModal.test.jsx
+++ b/frontend/src/components/Book/BookDetailModal.test.jsx
@@ -1,0 +1,144 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import BookDetailModal from "./BookDetailModal";
+import axios from "axios";
+import { toast } from "react-toastify";
+
+vi.mock("axios");
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockBook = {
+  _id: "123",
+  title: "test book",
+  author: "test author",
+  coverUrl: "test-url.jpg",
+  summary: "test summary",
+};
+
+describe("BookDetailModal", () => {
+  const onClose = vi.fn();
+  const onUpdateLibrary = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should not render when isOpen is false", () => {
+    render(
+      <BookDetailModal
+        book={mockBook}
+        isOpen={false}
+        onClose={onClose}
+        onUpdateLibrary={onUpdateLibrary}
+      />
+    );
+    expect(screen.queryByText(/test book/i)).not.toBeInTheDocument();
+  });
+  it("should render modal when isOpen is true", () => {
+    render(
+      <BookDetailModal
+        book={mockBook}
+        isOpen={true}
+        onClose={onClose}
+        onUpdateLibrary={onUpdateLibrary}
+      />
+    );
+    expect(screen.getByText(/test book/i)).toBeInTheDocument();
+    expect(screen.getByText(/by test author/i)).toBeInTheDocument();
+  });
+
+  it("should fetch and display note on mount", async () => {
+    axios.get.mockResolvedValueOnce({ data: { data: "Test note content" } });
+    render(
+      <BookDetailModal
+        book={mockBook}
+        isOpen={true}
+        onClose={onClose}
+        onUpdateLibrary={onUpdateLibrary}
+      />
+    );
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        "http://localhost:3000/api/books/mylibrary/123/notes",
+        { withCredentials: true }
+      );
+    });
+    expect(screen.getByText(/Test note content/i)).toBeInTheDocument();
+  });
+  it("should enter edit mode when clicking 'Add Book Notes' ", async () => {
+    axios.get.mockResolvedValueOnce({ data: { data: " " } });
+    render(
+      <BookDetailModal
+        book={mockBook}
+        isOpen={true}
+        onClose={onClose}
+        onUpdateLibrary={onUpdateLibrary}
+      />
+    );
+    await waitFor(() => screen.getByText(/Add Book Notes/i));
+    fireEvent.click(screen.getByText(/Add Book Notes/i));
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("should save note with POST if no original note", async () => {
+    axios.get.mockResolvedValueOnce({ data: { data: " " } });
+    axios.post.mockResolvedValueOnce({});
+
+    render(
+      <BookDetailModal
+        book={mockBook}
+        isOpen={true}
+        onClose={onClose}
+        onUpdateLibrary={onUpdateLibrary}
+      />
+    );
+    await waitFor(() => screen.getByText(/Add Book Notes/i));
+
+    fireEvent.click(screen.getByText(/Add Book Notes/i));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "New note" },
+    });
+    fireEvent.click(screen.getByText(/Save Note/i));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        "http://localhost:3000/api/books/mylibrary/123/notes",
+        { note: "New note" },
+        { withCredentials: true }
+      );
+      expect(toast.success).toHaveBeenCalledWith("Note Saved");
+    });
+  });
+  it("should delete the book when confirmed", async () => {
+    axios.get.mockResolvedValueOnce({ data: { data: "Existing note" } });
+    axios.delete.mockResolvedValueOnce({});
+
+    render(
+      <BookDetailModal
+        book={mockBook}
+        isOpen={true}
+        onClose={onClose}
+        onUpdateLibrary={onUpdateLibrary}
+      />
+    );
+    await waitFor(() => screen.getByText(/Remove Book From Library/i));
+    fireEvent.click(screen.getByText(/Remove Book From Library/i));
+    fireEvent.click(screen.getByText(/Confirm/i));
+
+    await waitFor(() => {
+      expect(axios.delete).toHaveBeenCalledWith(
+        "http://localhost:3000/api/books/mylibrary/123",
+        { withCredentials: true }
+      );
+      expect(toast.success).toHaveBeenCalledWith("Book deleted from library");
+      expect(onUpdateLibrary).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/Book/BowAnimation.jsx
+++ b/frontend/src/components/Book/BowAnimation.jsx
@@ -35,6 +35,7 @@ const BowAnimation = () => {
   return (
     <div
       ref={container}
+      role="presentation"
       className="w-[140px] cursor-pointer scale-x-[-1] scale-100"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}

--- a/frontend/src/components/Book/BowAnimation.test.jsx
+++ b/frontend/src/components/Book/BowAnimation.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import BowAnimation from "./BowAnimation";
+
+//Mock lottie-web methods
+const playSegmentsMock = vi.fn();
+const goToAndStopMock = vi.fn();
+const destroyMock = vi.fn();
+
+vi.mock("lottie-web", () => ({
+  default: {
+    loadAnimation: () => ({
+      playSegments: playSegmentsMock,
+      goToAndStop: goToAndStopMock,
+      destroy: destroyMock,
+    }),
+  },
+}));
+
+describe("BowAnimation", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the animation container", () => {
+    render(<BowAnimation />);
+    const container = screen.getByRole("presentation");
+    expect(container).toBeInTheDocument();
+  });
+
+  it("should initialise animation and stop at frame 21", () => {
+    render(<BowAnimation />);
+    expect(goToAndStopMock).toHaveBeenCalledWith(21, true);
+  });
+  it("should play the 'draw' segment on mouse enter", () => {
+    render(<BowAnimation />);
+    const container = screen.getByRole("presentation");
+    fireEvent.mouseEnter(container)
+    expect(playSegmentsMock).toHaveBeenCalledWith([21, 60], true)
+  });
+  it("should play 'idle' segment on mouse leave", () =>{
+    render(<BowAnimation/>)
+    const container = screen.getByRole("presentation")
+    fireEvent.mouseLeave(container)
+    expect(playSegmentsMock).toHaveBeenCalledWith([21,22], true)
+  })
+  it("should play 'fire' segment on mouse click", () =>{
+    render(<BowAnimation/>)
+    const container = screen.getByRole("presentation")
+    fireEvent.click(container)
+    expect(playSegmentsMock).toHaveBeenCalledWith([61, 85], true)
+  })
+  it("should clean up animation on unmount", () =>{
+    const {unmount }= render(<BowAnimation/>)
+    unmount()
+    expect(destroyMock).toHaveBeenCalled()
+  })
+});

--- a/frontend/src/components/Book/VideoCarousel.jsx
+++ b/frontend/src/components/Book/VideoCarousel.jsx
@@ -30,12 +30,14 @@ const VideoCarousel = ({ videos }) => {
     <>
       <div className="absolute  mt-70 inset-20 flex justify-between items-center pointer-events-none ">
         <button
+          aria-label="Previous Slide"
           onClick={prevSlide}
           className="p-2 rounded-full border border-white/20 shadow-md shadow-[#5E402D] hover:shadow-lg hover:shadow-[#5E1A1D]/70 hover:scale-102 bg-black/40 text-white transition pointer-events-auto cursor-pointer  active:scale-92"
         >
           <HiOutlineArrowSmallLeft size={24} />
         </button>
         <button
+          aria-label="Next Slide"
           onClick={nextSlide}
           className="p-2 rounded-full border border-white/20 shadow-md shadow-[#5E402D] hover:shadow-lg hover:shadow-[#5E1A1D]/70 hover:scale-102 bg-black/40 text-white transition pointer-events-auto cursor-pointer active:scale-92"
         >
@@ -93,6 +95,7 @@ const VideoCarousel = ({ videos }) => {
         <div className="flex justify-center mt-3 gap-1">
           {videos.map((_, index) => (
             <BsDot
+              data-testid="dot"
               key={index}
               onClick={() => setCurrentIndex(index)}
               className={`mt-3 cursor-pointer text-2xl text-shadow ${

--- a/frontend/src/components/Book/VideoCarousel.test.jsx
+++ b/frontend/src/components/Book/VideoCarousel.test.jsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforEach, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import VideoCarousel from "./VideoCarousel.jsx";
+
+const mockVideos = [
+  {
+    id: { videoId: "testId1" },
+    snippet: { title: "Test Video 1" },
+  },
+  {
+    id: { videoId: "testId2" },
+    snippet: { title: "Test Video 2" },
+  },
+  {
+    id: { videoId: "testId3" },
+    snippet: { title: "Test Video 3" },
+  },
+];
+
+describe("VideoCarousel", () => {
+  it("should render the first video by default", () => {
+    render(<VideoCarousel videos={mockVideos} />);
+    const iframe = screen.getByTitle("Test Video 1");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute("src", expect.stringContaining("testId1"));
+  });
+
+  it("should navigate to the next video on right arrow click", () => {
+    render(<VideoCarousel videos={mockVideos} />);
+    const nextButton = screen.getByLabelText("Next Slide");
+
+    fireEvent.click(nextButton);
+    const iframe = screen.getByTitle("Test Video 2");
+    expect(iframe).toBeInTheDocument();
+  });
+
+  it("should navigate to previous video on left arrow click", () => {
+    render(<VideoCarousel videos={mockVideos} />);
+    const leftArrow = screen.getByLabelText("Previous Slide");
+    fireEvent.click(leftArrow);
+
+    const iframe = screen.getByTitle("Test Video 3");
+    expect(iframe).toBeInTheDocument();
+  });
+  it("should navigate to the correct video when a dot is clicked", () => {
+    render(<VideoCarousel videos={mockVideos} />);
+    const dots = screen.getAllByTestId("dot");
+    fireEvent.click(dots[2]);
+    const iframe = screen.getByTitle("Test Video 3");
+    expect(iframe).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Add Unit Tests for Book Components

### Summary
This PR adds unit test coverage for all components within the `components/Book` directory. The tests aim to verify UI rendering, interactivity, and API behaviour.

### Components Tested
- **BookDetailModal**
  - Tests rendering behaviour based on `isOpen` prop
  - Mocks and verifies API call for fetching notes
  - Confirms display of book data and note content

- **VideoCarousel**
  - Ensures videos render correctly in the carousel
  - Verifies navigation using the arrow buttons

- **BowAnimation**
  - Mocks Lottie and simulates mouse events
  - Checks play/stop/click functionality on mouse events

### Notes
- All external dependencies like `axios` and `react-toastify` have been mocked
- Used `@testing-library/react` and `vitest` for testing